### PR TITLE
bootkube: override control-plane configs – fix kubectl logs

### DIFF
--- a/pkg/asset/ignition/bootstrap/bootstrap.go
+++ b/pkg/asset/ignition/bootstrap/bootstrap.go
@@ -183,6 +183,7 @@ func (a *Bootstrap) addBootstrapFiles(dependencies asset.Parents) {
 }
 
 func (a *Bootstrap) addBootkubeFiles(dependencies asset.Parents, templateData *bootstrapTemplateData) {
+	bootkubeConfigOverridesDir := filepath.Join(rootDir, "bootkube-config-overrides")
 	adminKubeconfig := &kubeconfig.Admin{}
 	manifests := &manifests.Manifests{}
 	dependencies.Get(adminKubeconfig, manifests)
@@ -191,6 +192,12 @@ func (a *Bootstrap) addBootkubeFiles(dependencies asset.Parents, templateData *b
 		a.Config.Storage.Files,
 		ignition.FileFromString("/opt/tectonic/bootkube.sh", 0555, applyTemplateData(content.BootkubeShFileTemplate, templateData)),
 	)
+	for _, o := range content.BootkubeConfigOverrides {
+		a.Config.Storage.Files = append(
+			a.Config.Storage.Files,
+			ignition.FileFromString(filepath.Join(bootkubeConfigOverridesDir, o.Name()), 0600, applyTemplateData(o, templateData)),
+		)
+	}
 	a.Config.Storage.Files = append(
 		a.Config.Storage.Files,
 		ignition.FilesFromAsset(rootDir, 0600, adminKubeconfig)...,


### PR DESCRIPTION
The installer will want to customize the control plane configuration. Here, this is used to set an empty kubectl CA in the kube-apiserver config to cope with self-signed kubelet serving certs. In follow-ups we have to set advertised domain names, cluster CIDRs and other settings using the same mechanisms.